### PR TITLE
use simpler [DynamicPrereqs] syntax

### DIFF
--- a/dist.ini.meta
+++ b/dist.ini.meta
@@ -23,34 +23,8 @@ srcreadme         = mkdn
 
 [Prereqs]
 ; authordep Pod::Elemental::Transformer::List
-Mixin::Linewise = != 0.107
+Mixin::Linewise = != 0.107  ; not understood except on very new EUMM
 
 [DynamicPrereqs]
--delimiter = |
--raw = |unless ( eval { ExtUtils::MakeMaker->VERSION(6.53_03) } ) {
--raw = |  *MM::_installed_file_for_module = sub {
--raw = |    my $class  = shift;
--raw = |    my $prereq = shift;
--raw = |    my $file = "$prereq.pm";
--raw = |    $file =~ s{::}{/}g;
--raw = |    my $path;
--raw = |    for my $dir (@INC) {
--raw = |      my $tmp = File::Spec->catfile($dir, $file);
--raw = |      if ( -r $tmp ) {
--raw = |        $path = $tmp;
--raw = |        last;
--raw = |      }
--raw = |    }
--raw = |    return $path;
--raw = |  }
--raw = |}
--raw = |
--raw = |unless ( eval { ExtUtils::MakeMaker->VERSION(7.05_01) } ) {
--raw = |  my $module = "Mixin::Linewise";
--raw = |  my $want    = "0";
--raw = |  my $path    = MM->_installed_file_for_module( $module );
--raw = |  if ( $path and ( MM->parse_version( $path ) || q[] ) eq q[0.107] ) {
--raw = |    $want = "0.108";
--raw = |  };
--raw = |  $FallbackPrereqs{$module} = $WriteMakefileArgs{PREREQ_PM}->{$module} = $want;
--raw = |}
+:version = 0.016
+-raw = require('Mixin::Linewise', '0.108') if has_module('Mixin::Linewise', '0.107');


### PR DESCRIPTION
This is _much_ more compact! :)

(Also note that the version range handling in EUMM was removed between 7.06 and 7.08, and still remains out, along with most of the 7.05\* changes that were reverted.)

Also, when building the distribution, I got:

```
[Bootstrap::lib] Bootstrapping lib
[DZ] beginning to build Dist-Zilla-Util-ExpandINI
[DZ] guessing dist's main_module is lib/Dist/Zilla/Util/ExpandINI.pm
[@Author::KENTNL/always_latest_develop_bundle] You asked for the installed version of Dist::Zilla::PluginBundle::Author::KENTNL, and it is a dependency but it is apparently not installed
[@Author::KENTNL/MakeMaker] found version range in runtime prerequisites, which ExtUtils::MakeMaker cannot parse: Mixin::Linewise != 0.107
[@Author::KENTNL/Author::KENTNL::RecommendFixes] should_not have_line: dist.ini.meta Has line matching (?^:copyfiles\s*=.*LICENSE)
[@Author::KENTNL/Author::KENTNL::RecommendFixes] should exist: CONTRIBUTING.pod does not exist
[@Author::KENTNL/Author::KENTNL::RecommendFixes] should exist: Makefile.PL does not exist
[@Author::KENTNL/Author::KENTNL::RecommendFixes] should have_line: .gitignore Does not have line matching (?^:\A/\.build\z)
[@Author::KENTNL/Author::KENTNL::RecommendFixes] should have_line: .gitignore Does not have line matching (?^:\A/tmp/\z)
[@Author::KENTNL/Author::KENTNL::RecommendFixes] should have_line: .gitignore Does not have line matching (?^u:\A/Dist\-Zilla\-Util\-ExpandINI-\*\z)
[@Author::KENTNL/Author::KENTNL::RecommendFixes] should_not have_line: .gitignore Has line matching (?^u:\ADist\-Zilla\-Util\-ExpandINI-\*\z)
[DZ] writing Dist-Zilla-Util-ExpandINI in Dist-Zilla-Util-ExpandINI-0.003002
uname: illegal option -- o
usage: uname [-amnprsv]
[@Author::KENTNL/MetaData::BuiltWith] obj(Dist::Zilla::Plugin::MetaData::BuiltWith=HASH(0x7fe882724460))
[@Author::KENTNL/MetaData::BuiltWith]    $@:Error calling uname:
[@Author::KENTNL/MetaData::BuiltWith]    $!:
[@Author::KENTNL/MetaData::BuiltWith] obj(Dist::Zilla::Plugin::MetaData::BuiltWith=HASH(0x7fe882724460))
[@Author::KENTNL/MetaData::BuiltWith]    $@:Error calling uname:
[@Author::KENTNL/MetaData::BuiltWith]    $!: at /Volumes/amaretto/Users/ether/.perlbrew/libs/23.3@std/lib/perl5/darwin-2level/Moose/Meta/Method/Delegation.pm line 110.

```
